### PR TITLE
Production environment reload error fix

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,13 @@ if (process.env.NODE_ENV === "production") {
   app.use(express.static('client/build'));
 }
 
+// Catch all route to redirect unmanaged routes back to the react app.
+// THIS OPTION IS NOT SEO OPTIMIZED
+// THIS ROUTE SENDS ALL SAVED LINKS TO THE ROOT
+app.get('/*', function (req, res) {
+  res.redirect('/')
+});
+
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use(express.static('public'));


### PR DESCRIPTION
This is a fix for the cannot get /whatever-route error when you hit refresh. This is not an SEO optimized option but it should get it working.